### PR TITLE
👷 Add missing file types

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "*.js": "eslint --fix --cache",
+  "*.{js,jsx,ts,tsx}": "eslint --fix --cache",
   "*.css": "stylelint --fix",
-  "*.{js,css,html,json,md}": "prettier --write"
+  "*.{js,jsx,ts,tsx,css,html,json,md,mdx}": "prettier --write"
 }


### PR DESCRIPTION
We forgot to update lint staged to lint TypeScript and React modules. 

Read more about [how to filter files in lint-staged](https://github.com/okonet/lint-staged#filtering-files).